### PR TITLE
Add Imaginarium rule scaffolding

### DIFF
--- a/ptcg-server/src/game/imaginarium/index.ts
+++ b/ptcg-server/src/game/imaginarium/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/ptcg-server/src/game/imaginarium/types.ts
+++ b/ptcg-server/src/game/imaginarium/types.ts
@@ -1,0 +1,31 @@
+export enum GemType {
+  EMERALD = 'Emerald',
+  SAPPHIRE = 'Sapphire',
+  AMETHYST = 'Amethyst',
+  RUBY = 'Ruby',
+  TOPAZ = 'Topaz',
+}
+
+export enum ImaginariumCondition {
+  WOUNDED,
+  DISABLED,
+}
+
+export enum PowerKind {
+  PASSIVE,
+  CONDITIONAL,
+  TRIGGERED,
+}
+
+export interface GemEffectiveness {
+  strongAgainst: GemType[];
+  weakAgainst: GemType[];
+}
+
+export const GEM_EFFECTIVENESS: Record<GemType, GemEffectiveness> = {
+  [GemType.EMERALD]: { strongAgainst: [GemType.RUBY], weakAgainst: [GemType.SAPPHIRE] },
+  [GemType.SAPPHIRE]: { strongAgainst: [GemType.EMERALD], weakAgainst: [GemType.RUBY] },
+  [GemType.AMETHYST]: { strongAgainst: [], weakAgainst: [] },
+  [GemType.RUBY]: { strongAgainst: [GemType.SAPPHIRE], weakAgainst: [GemType.EMERALD] },
+  [GemType.TOPAZ]: { strongAgainst: [], weakAgainst: [] },
+};

--- a/ptcg-server/src/game/index.ts
+++ b/ptcg-server/src/game/index.ts
@@ -18,6 +18,7 @@ export * from './store/actions/game-actions';
 export * from './store/actions/invite-player-action';
 export * from './store/actions/play-card-action';
 export * from './store/actions/reorder-actions';
+export * from './imaginarium';
 export * from './store/actions/resolve-prompt-action';
 
 export * from './store/card/card-types';

--- a/ptcg-server/src/game/store/card/card-types.ts
+++ b/ptcg-server/src/game/store/card/card-types.ts
@@ -59,6 +59,7 @@ export enum TrainerType {
   SUPPORTER,
   STADIUM,
   TOOL,
+  IMPLEMENT,
 }
 
 export enum PokemonType {
@@ -170,7 +171,9 @@ export enum SpecialCondition {
   POISONED,
   BURNED,
   ABILITY_USED,
-  POWER_GLOW
+  POWER_GLOW,
+  WOUNDED,
+  DISABLED
 }
 
 export enum BoardEffect {

--- a/ptcg-server/src/game/store/reducers/play-card-reducer.ts
+++ b/ptcg-server/src/game/store/reducers/play-card-reducer.ts
@@ -109,6 +109,9 @@ export function playCardReducer(store: StoreLike, state: State, action: Action):
             }
             effect = new AttachPokemonToolEffect(player, handCard, target);
             break;
+          case TrainerType.IMPLEMENT:
+            effect = new PlayItemEffect(player, handCard, target);
+            break;
           default:
             effect = new PlayItemEffect(player, handCard, target);
             break;

--- a/ptcg-server/src/game/store/state/card-list.ts
+++ b/ptcg-server/src/game/store/state/card-list.ts
@@ -158,6 +158,7 @@ export class CardList {
     if (input === TrainerType.ITEM) return 2;
     if (input === TrainerType.TOOL) return 3;
     if (input === TrainerType.STADIUM) return 4;
+    if (input === TrainerType.IMPLEMENT) return 5;
     return Infinity;
   }
   

--- a/ptcg-server/src/utils/dice.ts
+++ b/ptcg-server/src/utils/dice.ts
@@ -1,0 +1,25 @@
+export interface DiceResult {
+  rolls: number[];
+  total: number;
+}
+
+export function rollDice(notation: string): DiceResult {
+  const match = notation.match(/(\d+)D(\d+)([+X])?/i);
+  if (!match) {
+    throw new Error(`Invalid dice notation: ${notation}`);
+  }
+  const count = parseInt(match[1], 10);
+  const sides = parseInt(match[2], 10);
+  const modifier = match[3];
+  const rolls: number[] = [];
+  for (let i = 0; i < count; i++) {
+    rolls.push(Math.floor(Math.random() * sides) + 1);
+  }
+  let total = rolls.reduce((a, b) => a + b, 0);
+  if (modifier === 'X') {
+    total *= count;
+  } else if (modifier === '+') {
+    total += count;
+  }
+  return { rolls, total };
+}

--- a/ptcg-server/src/utils/index.ts
+++ b/ptcg-server/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './base64';
 export * from './logger';
 export * from './scheduler';
 export * from './utils';
+export * from './dice';

--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,7 @@ Each player:
     Attaches Gemstones to meet attack costs
 
     Rolls dice to determine damage output
+    Applies type effectiveness and status conditions
 
     Knocks out enemy Characters by reducing LP to 0
 


### PR DESCRIPTION
## Summary
- extend trainer types with IMPLEMENT and handle sorting
- include new status conditions
- initial gem-type module and dice rolling utility
- export new helpers and Imaginarium utilities
- small documentation update

## Testing
- `npm test` in `ptcg-server`
- `npx ng test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843189f8ac8833390ad4f6b36283ad5