### PR TITLE
Add Imaginarium card set

### DIFF
--- a/ptcg-server/output/sets/index.d.ts
+++ b/ptcg-server/output/sets/index.d.ts
@@ -105,6 +105,7 @@ export * from './set-prismatic-evolution';
 export * from './set-sv9';
 export * from './set-sv9a';
 export * from './set-sv10';
+export * from './set-imaginarium';
 export * from './set-test';
 export * from './set-legends-awakened';
 export * from './set-stormfront';

--- a/ptcg-server/output/sets/index.js
+++ b/ptcg-server/output/sets/index.js
@@ -128,6 +128,7 @@ __exportStar(require("./set-prismatic-evolution"), exports);
 __exportStar(require("./set-sv9"), exports);
 __exportStar(require("./set-sv9a"), exports);
 __exportStar(require("./set-sv10"), exports);
+__exportStar(require("./set-imaginarium"), exports);
 //TEST
 __exportStar(require("./set-test"), exports);
 //Sort Later

--- a/ptcg-server/output/sets/set-imaginarium/index.d.ts
+++ b/ptcg-server/output/sets/set-imaginarium/index.d.ts
@@ -1,0 +1,2 @@
+import { Card } from '../../game/store/card/card';
+export declare const setImaginarium: Card[];

--- a/ptcg-server/output/sets/set-imaginarium/index.js
+++ b/ptcg-server/output/sets/set-imaginarium/index.js
@@ -1,0 +1,65 @@
+'use strict';
+const path = require('path');
+const fs = require('fs');
+const game = require('../../game');
+class CharacterCard extends game.PokemonCard {
+  constructor(data) {
+    super();
+    this.name = data.title;
+    this.fullName = `${data.title} IMAG`;
+    this.set = 'IMAG';
+    this.setNumber = data.id || data.cardNumber || '';
+    this.cardImage = data.image || 'assets/cardback.png';
+    this.stage = game.Stage.BASIC;
+    this.cardType = game.CardType.COLORLESS;
+    this.hp = data.lp || 0;
+    this.attacks = [];
+    if (data.attack1) {
+      this.attacks.push({ name: data.attack1, cost: [], damage: 0, text: data.attack1 });
+    }
+    if (data.attack2) {
+      this.attacks.push({ name: data.attack2, cost: [], damage: 0, text: data.attack2 });
+    }
+  }
+  reduceEffect(store, state, effect) { return state; }
+}
+class ImplementCard extends game.TrainerCard {
+  constructor(data) {
+    super();
+    this.name = data.title;
+    this.fullName = `${data.title} IMAG`;
+    this.set = 'IMAG';
+    this.setNumber = data.id || data.cardNumber || '';
+    this.cardImage = data.image || 'assets/cardback.png';
+    this.trainerType = game.TrainerType.IMPLEMENT;
+    this.text = [data.attack1, data.attack2].filter(Boolean).join(' ');
+  }
+  reduceEffect(store, state, effect) { return state; }
+}
+class PowerCard extends game.EnergyCard {
+  constructor(data) {
+    super();
+    this.name = data.title;
+    this.fullName = `${data.title} IMAG`;
+    this.set = 'IMAG';
+    this.setNumber = data.id || data.cardNumber || '';
+    this.cardImage = data.image || 'assets/cardback.png';
+    this.energyType = game.EnergyType.BASIC;
+    this.provides = [game.CardType.COLORLESS];
+  }
+}
+const dataPath = path.resolve(__dirname, '../../../../cards_updated.json');
+const cardsData = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+const setImaginarium = cardsData.map(info => {
+  switch (info.type) {
+    case 'Character':
+      return new CharacterCard(info);
+    case 'Implement':
+      return new ImplementCard(info);
+    case 'Power':
+      return new PowerCard(info);
+    default:
+      return new CharacterCard(info);
+  }
+});
+module.exports = { setImaginarium };

--- a/ptcg-server/src/game/imaginarium/index.ts
+++ b/ptcg-server/src/game/imaginarium/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/ptcg-server/src/game/imaginarium/types.ts
+++ b/ptcg-server/src/game/imaginarium/types.ts
@@ -1,0 +1,31 @@
+export enum GemType {
+  EMERALD = 'Emerald',
+  SAPPHIRE = 'Sapphire',
+  AMETHYST = 'Amethyst',
+  RUBY = 'Ruby',
+  TOPAZ = 'Topaz',
+}
+
+export enum ImaginariumCondition {
+  WOUNDED,
+  DISABLED,
+}
+
+export enum PowerKind {
+  PASSIVE,
+  CONDITIONAL,
+  TRIGGERED,
+}
+
+export interface GemEffectiveness {
+  strongAgainst: GemType[];
+  weakAgainst: GemType[];
+}
+
+export const GEM_EFFECTIVENESS: Record<GemType, GemEffectiveness> = {
+  [GemType.EMERALD]: { strongAgainst: [GemType.RUBY], weakAgainst: [GemType.SAPPHIRE] },
+  [GemType.SAPPHIRE]: { strongAgainst: [GemType.EMERALD], weakAgainst: [GemType.RUBY] },
+  [GemType.AMETHYST]: { strongAgainst: [], weakAgainst: [] },
+  [GemType.RUBY]: { strongAgainst: [GemType.SAPPHIRE], weakAgainst: [GemType.EMERALD] },
+  [GemType.TOPAZ]: { strongAgainst: [], weakAgainst: [] },
+};

--- a/ptcg-server/src/game/index.ts
+++ b/ptcg-server/src/game/index.ts
@@ -18,6 +18,7 @@ export * from './store/actions/game-actions';
 export * from './store/actions/invite-player-action';
 export * from './store/actions/play-card-action';
 export * from './store/actions/reorder-actions';
+export * from './imaginarium';
 export * from './store/actions/resolve-prompt-action';
 
 export * from './store/card/card-types';

--- a/ptcg-server/src/game/store/card/card-types.ts
+++ b/ptcg-server/src/game/store/card/card-types.ts
@@ -59,6 +59,7 @@ export enum TrainerType {
   SUPPORTER,
   STADIUM,
   TOOL,
+  IMPLEMENT,
 }
 
 export enum PokemonType {
@@ -170,7 +171,9 @@ export enum SpecialCondition {
   POISONED,
   BURNED,
   ABILITY_USED,
-  POWER_GLOW
+  POWER_GLOW,
+  WOUNDED,
+  DISABLED
 }
 
 export enum BoardEffect {

--- a/ptcg-server/src/game/store/reducers/play-card-reducer.ts
+++ b/ptcg-server/src/game/store/reducers/play-card-reducer.ts
@@ -109,6 +109,9 @@ export function playCardReducer(store: StoreLike, state: State, action: Action):
             }
             effect = new AttachPokemonToolEffect(player, handCard, target);
             break;
+          case TrainerType.IMPLEMENT:
+            effect = new PlayItemEffect(player, handCard, target);
+            break;
           default:
             effect = new PlayItemEffect(player, handCard, target);
             break;

--- a/ptcg-server/src/game/store/state/card-list.ts
+++ b/ptcg-server/src/game/store/state/card-list.ts
@@ -158,6 +158,7 @@ export class CardList {
     if (input === TrainerType.ITEM) return 2;
     if (input === TrainerType.TOOL) return 3;
     if (input === TrainerType.STADIUM) return 4;
+    if (input === TrainerType.IMPLEMENT) return 5;
     return Infinity;
   }
   

--- a/ptcg-server/src/utils/dice.ts
+++ b/ptcg-server/src/utils/dice.ts
@@ -1,0 +1,25 @@
+export interface DiceResult {
+  rolls: number[];
+  total: number;
+}
+
+export function rollDice(notation: string): DiceResult {
+  const match = notation.match(/(\d+)D(\d+)([+X])?/i);
+  if (!match) {
+    throw new Error(`Invalid dice notation: ${notation}`);
+  }
+  const count = parseInt(match[1], 10);
+  const sides = parseInt(match[2], 10);
+  const modifier = match[3];
+  const rolls: number[] = [];
+  for (let i = 0; i < count; i++) {
+    rolls.push(Math.floor(Math.random() * sides) + 1);
+  }
+  let total = rolls.reduce((a, b) => a + b, 0);
+  if (modifier === 'X') {
+    total *= count;
+  } else if (modifier === '+') {
+    total += count;
+  }
+  return { rolls, total };
+}

--- a/ptcg-server/src/utils/index.ts
+++ b/ptcg-server/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './base64';
 export * from './logger';
 export * from './scheduler';
 export * from './utils';
+export * from './dice';

--- a/ptcg-server/start.js
+++ b/ptcg-server/start.js
@@ -141,6 +141,7 @@ cardManager.defineSet(sets.setSV9a);
 cardManager.defineSet(sets.setSV10);
 
 cardManager.defineSet(sets.setTest);
+cardManager.defineSet(sets.setImaginarium);
 
 cardManager.defineSet(sets.setLegendsAwakened);
 cardManager.defineSet(sets.setStormfront);

--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,7 @@ Each player:
     Attaches Gemstones to meet attack costs
 
     Rolls dice to determine damage output
+    Applies type effectiveness and status conditions
 
     Knocks out enemy Characters by reducing LP to 0
 


### PR DESCRIPTION
## Summary
- define an Imaginarium set loaded from the cards_updated.json data
- export the set from the sets index and load it on server startup

## Testing
- `npm test` in `ptcg-server`
- `npx ng test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6843189f8ac8833390ad4f6b36283ad5