### PR TITLE
Add card images support

### DIFF
--- a/ptcg-server/config.js
+++ b/ptcg-server/config.js
@@ -9,4 +9,5 @@ config.backend.avatarsDir = __dirname + '/avatars';
 
 config.bots.defaultPassword = 'bot';
 
-config.sets.scansDir = __dirname + '/scans';
+config.sets.scansDir = __dirname + '/src/assets/images';
+config.sets.scansUrl = 'http://localhost:8080{cardImage}';

--- a/ptcg-server/src/backend/app.ts
+++ b/ptcg-server/src/backend/app.ts
@@ -60,6 +60,7 @@ export class App {
 
     if (config.sets.scansDir) {
       app.use('/scans', express.static(config.sets.scansDir));
+      app.use('/assets/images', express.static(config.sets.scansDir));
     }
     app.use('/avatars', express.static(config.backend.avatarsDir));
 


### PR DESCRIPTION
## Summary
- serve new images folder as static assets
- set scansDir and scansUrl to serve local card images

## Testing
- `npm test` *(fails: nyc not found)*
- `npm test` in ptcg-play *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684347d086a083338622ebec41413690